### PR TITLE
read_dhs_dta() and anemia vignette

### DIFF
--- a/R/read_dhs_dta.R
+++ b/R/read_dhs_dta.R
@@ -8,6 +8,13 @@
 #' @details Currently hardcoded for 111 char width .MAP files, which covers the vast majority
 #' of DHS Phase V, VI, and VIII. To be extended in the future and perhaps add other useful options.
 #'
+#' @examples
+#' mrdt_zip <- tempfile()
+#' download.file("https://dhsprogram.com/customcf/legacy/data/sample_download_dataset.cfm?Filename=ZZMR61DT.ZIP&Tp=1&Ctry_Code=zz&survey_id=0&doctype=dhs", mrdt_zip)
+#'
+#' map <- read_zipdata(mrdt_zip, "\\.MAP", readLines)
+#' dct <- parse_map(map)
+#'
 #' @export
 parse_map <- function(map, all_lower=TRUE){
 
@@ -150,14 +157,14 @@ parse_map <- function(map, all_lower=TRUE){
 #' @examples
 #' mrdt_zip <- tempfile()
 #' download.file("https://dhsprogram.com/customcf/legacy/data/sample_download_dataset.cfm?Filename=ZZMR61DT.ZIP&Tp=1&Ctry_Code=zz&survey_id=0&doctype=dhs", mrdt_zip)
-
+#'
 #' mr <- read_dhs_dta(mrdt_zip)
 #' attr(mr$mv213, "label")
 #' class(mr$mv213)
 #' head(mr$mv213)
 #' table(mr$mv213)
 #' table(haven::as_factor(mr$mv213))
-
+#' 
 #' ## If Stata file codebook is complete, `mode="map"` and `"haven"` should be the same.
 #' mr_hav <- read_dhs_dta(mrdt_zip, mode="haven")
 #' attr(mr_hav$mv213, "label")
@@ -165,21 +172,20 @@ parse_map <- function(map, all_lower=TRUE){
 #' head(mr_hav$mv213)  # "9=missing" omitted from .dta codebook
 #' table(mr_hav$mv213)
 #' table(haven::as_factor(mr_hav$mv213))
-
+#'
 #' ## Parsing codebook when using foreign::read.dta()
 #' mr_for <- read_dhs_dta(mrdt_zip, mode="foreign")
 #' attr(mr_for, "var.labels")[names(mr_for) == "mv213"]
 #' attr(mr_for, "val.labels")[names(mr_for) == "mv213"]
 #' attr(mr_for, "label.table")["MV213"]
 #' table(mr_for$mv213)
-
+#'
 #' ## Don't convert factors
 #' mr_raw <- read_dhs_dta(mrdt_zip, mode="raw")
 #' table(mr_raw$mv213)
-
+#'
 #' @importFrom hhsurveydata read_zipdata
 #' @export
-
 read_dhs_dta <- function(zfile, mode="map", all_lower=TRUE) {
 
   if(!mode %in% c("map", "haven", "foreign", "raw", "foreignNA"))

--- a/R/read_dhs_dta.R
+++ b/R/read_dhs_dta.R
@@ -1,0 +1,326 @@
+#' Create dictionary from DHS .MAP codebook
+#'
+#' @param map A character vector containing .MAP file, e.g. from `readLines()`.
+#' @param all_lower Logical indicating whether all value labels should be converted to lower case
+#' @return A data frame containing metadata, principally variable labels and
+#' a vector of value labels.
+#'
+#' @details Currently hardcoded for 111 char width .MAP files, which covers the vast majority
+#' of DHS Phase V, VI, and VIII. To be extended in the future and perhaps add other useful options.
+#'
+#' @export
+parse_map <- function(map, all_lower=TRUE){
+
+  ## Parse code book table between horizontal rules
+  ## Ignore first char of line which may be escape character
+  hr_idx <- which(substr(map, 2, 5) == "----")
+
+  header <- map[seq.int(hr_idx[length(hr_idx)-3]+1, hr_idx[length(hr_idx)-2]-1)]
+  dat <- map[seq.int(hr_idx[length(hr_idx)-2]+1, hr_idx[length(hr_idx)-1]-1)]
+
+  ## Identify variable lines based on flush left variable name
+  var_idx <- which(substr(dat, 1, 2) != '  ')
+  var <- dat[var_idx]
+
+  ## Identify column breaks based on white space in header. Then check that white
+  ## spaces also occur in variable rows (>0.7 arbitrarily) to exclude white spaces
+  ## in header variable names.
+
+  hspaces <- sapply(strsplit(header, NULL), "==", " ")
+  hspaces <- which(apply(hspaces, 1, all))
+  hspaces <- setdiff(hspaces+1, hspaces)-1
+
+  Sys.setlocale('LC_ALL','C')   ## !!! TODO
+  vspaces <- sapply(strsplit(var, NULL), "==", " ")
+  vspaces <- which(apply(vspaces, 1, mean) > 0.7)
+
+  idx1 <- c(intersect(hspaces, vspaces), max(nchar(c(header, var))))
+  idx0 <- idx1 - diff(c(0, idx1)) + 1
+
+  var <- Map(substr, list(x=var), start=idx0, stop=idx1)
+  var <- lapply(var, gsub, pattern="^\\s+", replacement="")
+  var <- lapply(var, gsub, pattern="\\s+$", replacement="")
+  var <- data.frame(var, stringsAsFactors=FALSE)
+
+  header <- Map(substr, list(x=header), start=idx0, stop=idx1)
+  header <- lapply(header, gsub, pattern="^\\s+", replacement="")
+  header <- lapply(header, gsub, pattern="\\s+$", replacement="")
+  header <- gsub("^\\s", "", sapply(header, paste, collapse=" "))
+
+  names(var) <- tolower(header)
+  var$name <- tolower(gsub("\\s+.*", "", var[["item name"]]))
+  var$label <- tolower(var[["item label"]])
+  var$start <- as.integer(var$start)
+  var$len <- as.integer(var$len)
+  var$occ <- as.integer(var$occ)
+
+  ## Parse value labels
+
+  .parse_labels <- function(x, is_alpha=FALSE, all_lower=TRUE){
+    maxch <- max(nchar(x))
+    x <- gsub("^(\\s+?)\\(m\\)", "\\1   ", x) # replance "(m)" with "   "
+    x <- gsub("^(\\s+?)\\(na\\)", "\\1    ", x) # replance "(na)" with "    "
+    charid <- do.call(c, lapply(lapply(strsplit(x, NULL), "!=", " "), which))
+    idx <- seq_len(maxch)[-charid]
+    idx <- sort(setdiff(idx+1, idx))[1:2]
+    x <- Map(substr, x=list(x), start=idx, stop=c(idx[-1]-1, maxch))
+    value <- x[[length(x)-1]]
+    if(is_alpha){
+      value <- gsub("^\\s+", "", gsub("\\s+$", "", value))
+      value[nchar(value) == 0] <- NA
+    } else
+      value <- suppressWarnings(as.integer(value))
+    label <- gsub("^\\s+", "", gsub("\\s+$", "", x[[length(x)]]))
+    if(all_lower)
+      label <- tolower(label)
+    names(value) <- label
+    value[!is.na(value) & nchar(names(value)) > 0]
+  }
+
+
+  nval <- diff(c(var_idx, length(dat))) - 1
+  hasval <- nval > 0
+  val <- Map(function(i, n) dat[i+1:n], i=var_idx[hasval], nval[hasval])
+  names(val) <- var$name[hasval]
+
+  var$labels <- list(NULL)
+  var$labels[hasval] <- Map(.parse_labels, x=val, is_alpha=var[["data type"]][hasval] == "AN", all_lower=all_lower)
+
+  ## Expand dictionary for repeated occurrence variables
+
+  .expand_occ <- function(name, label, start, len, labels, occ){
+    v <- data.frame(name   = paste0(name, "_", formatC(seq_len(occ), width=nchar(occ), flag="0")),
+                    label  = label,
+                    start  = start - len + seq_len(occ)*len,
+                    stringsAsFactors = FALSE)
+    v$labels <- list(labels)
+    return(v)
+  }
+
+  dct <- c(f=.expand_occ, var[var$occ > 1, c("name", "label", "start", "len", "labels", "occ")])
+  dct <- do.call(Map, dct)
+  dct <- do.call(rbind, dct)
+  dct <- rbind(var[var$occ == 1, names(dct)], dct)
+  dct <- dct[order(dct$start),]
+  rownames(dct) <- dct$name
+
+  return(dct)
+}
+
+#' Read DHS Stata data set
+#'
+#' This function reads a DHS recode dataset from the zipped Stata dataset. By default (`mode = "map"`),
+#' it rebuids the variable labels and value labels from the .MAP codebook.
+#'
+#' @param zfile Path to `.zip` file containing Stata dataset, usually ending in filename `XXXXXXDT.zip`
+#' @param mode Read mode for Stata `.dta` file. Defaults to "map", see 'Details' for other options.
+#' @param all_lower Logical indicating whether all value labels should be lower case. Default to `TRUE`.
+#' @return A data frame. If mode = 'map', value labels for each variable are stored as the `labelled` class from `haven`.
+#'
+#' @details
+#' The default `mode="map"` uses the `.MAP` dictionary file provided with the DHS Stata datasets
+#' to reconstruct the variable labels and value labels. In this case, value labels are stored are stored
+#' using the the `labelled` class from `haven`. See `?haven::labelled` for more information. Variable labels
+#' are stored in the "label" attribute of each variable, the same as `haven::read_dta()`.
+#'
+#' Currently, `mode="map"` is only implemented for 111 character fixed-width .MAP files, which comprises
+#' the vast majority of recode data files from DHS Phases V, VI, and VII and some from Phase IV. Parsers
+#' for other .MAP formats will be added in future.
+#'
+#' Other available modes read labels from the Stata dataset with various options available in R:
+#'
+#' * `mode="haven"`: use `haven::read_dta()` to read dataset. This option retains the native value codings
+#' with value labels affixed with the 'labelled' class.
+#'
+#' * `mode="foreign"`: use `foreign::read.dta()`, with default option convert.factors=TRUE to add
+#' variable labels. Note that variable labels will not be added if labels are not present for all
+#' values, but variable labels are available via the "val.labels" attribute.
+#'
+#' * `mode="foreignNA"`: use `foreign::read.dta(..., convert.factors=NA)`, which converts any values
+#' without labels to 'NA'. This risks data loss if labelling is incomplete in Stata datasets.
+#'
+#' * `mode="raw"`: use `foreign::read.dta(..., convert.factors=FALSE)`, which simply loads underlying
+#' value coding. Variable labels and value lables are still available through dataset attributes (see examples).
+#'
+#' @seealso \code{\link{foreign::read.dta}}, \code{\link{haven::labelled}}, \code{\link{haven::read_dta}}.
+#'
+#' For more information on the DHS filetypes and contents of distributed dataset .ZIP files,
+#' see \url{https://dhsprogram.com/data/File-Types-and-Names.cfm#CP_JUMP_10334}.
+#'
+#' @examples
+#' mrdt_zip <- tempfile()
+#' download.file("https://dhsprogram.com/customcf/legacy/data/sample_download_dataset.cfm?Filename=ZZMR61DT.ZIP&Tp=1&Ctry_Code=zz&survey_id=0&doctype=dhs", mrdt_zip)
+
+#' mr <- read_dhs_dta(mrdt_zip)
+#' attr(mr$mv213, "label")
+#' class(mr$mv213)
+#' head(mr$mv213)
+#' table(mr$mv213)
+#' table(haven::as_factor(mr$mv213))
+
+#' ## If Stata file codebook is complete, `mode="map"` and `"haven"` should be the same.
+#' mr_hav <- read_dhs_dta(mrdt_zip, mode="haven")
+#' attr(mr_hav$mv213, "label")
+#' class(mr_hav$mv213)
+#' head(mr_hav$mv213)  # "9=missing" omitted from .dta codebook
+#' table(mr_hav$mv213)
+#' table(haven::as_factor(mr_hav$mv213))
+
+#' ## Parsing codebook when using foreign::read.dta()
+#' mr_for <- read_dhs_dta(mrdt_zip, mode="foreign")
+#' attr(mr_for, "var.labels")[names(mr_for) == "mv213"]
+#' attr(mr_for, "val.labels")[names(mr_for) == "mv213"]
+#' attr(mr_for, "label.table")["MV213"]
+#' table(mr_for$mv213)
+
+#' ## Don't convert factors
+#' mr_raw <- read_dhs_dta(mrdt_zip, mode="raw")
+#' table(mr_raw$mv213)
+
+#' @importFrom hhsurveydata read_zipdata
+#' @export
+
+read_dhs_dta <- function(zfile, mode="map", all_lower=TRUE) {
+
+  if(!mode %in% c("map", "haven", "foreign", "raw", "foreignNA"))
+    stop(paste0("'", mode, "' is not a recognized read 'mode'"))
+
+  if(mode == "haven")
+    dat <- as.data.frame(read_zipdata(zfile, "\\.dta$", haven::read_dta))
+  if(mode == "foreign")
+    dat <- read_zipdata(zfile, "\\.dta$", foreign::read.dta)
+  if(mode == "foreignNA")
+    dat <- read_zipdata(zfile, "\\.dta$", foreign::read.dta, convert.factors = NA)
+  if(mode == "raw")
+    dat <- read_zipdata(zfile, "\\.dta$", foreign::read.dta, convert.factors = FALSE)
+
+  if(mode == "map"){
+    dat <- read_zipdata(zfile, "\\.dta$", foreign::read.dta, convert.factors = FALSE)
+    map <- read_zipdata(zfile, "\\.MAP$", readLines)
+    dct <- parse_map(map)
+    dat[dct$name] <- Map("attr<-", dat[dct$name], "label", dct$label)
+    haslbl <- sapply(dct$labels, length) > 0
+    dat[dct$name[haslbl]] <- Map(haven::labelled, dat[dct$name[haslbl]], dct$labels[haslbl])
+  }
+  return(dat)
+}
+
+#' Combine data frames with columes of class `labelled`
+#'
+#' @param ... data frames to bind together, potentially with columns of
+#' class "labelled". The first argument can be a list of data frames, similar
+#' to `plyr::rbind.fill`.
+#' @param labels A named list providing vectors of value labels or describing
+#' how to handle columns of class `labelled`. See details for usage.
+#' @param warn Logical indicating to warn if combining variables with different
+#' value labels. Defaults to TRUE.
+#'
+#' @return A data frame.
+#'
+#' @details
+#' The argument `labels` provides options for how to handle binding of
+#' columns of class `labelled`. Typical use is to provide a named list
+#' with elements for each labelled column. Elements of the list
+#' are either a vector of labels that should be applied to the column
+#' or the character string "concatenated", which indicates that labels
+#' should be concatenated such that all unique labels are distinct
+#' values in the combined vector. This is accomplished by converting
+#' to character strings, binding, and then casting back to labelled.
+#' For labelled columns for which labels are not provided in the `label`
+#' argument, the default behaviour is that the labels from the first
+#' data frame with labels for that column are inherited by the combined
+#' data.
+#'
+#' See examples.
+#'
+#' @examples
+#' df1 <- data.frame(area    = labelled(c(1L, 2L, 3L), c("reg 1" = 1, "reg 2" = 2, "reg 3" = 3)),
+##'                   climate = labelled(c(0L, 1L, 1L), c("cold" = 0, "hot" = 1)))
+#' df2 <- data.frame(area    = labelled(c(1L, 2L), c("reg A" = 1, "reg B" = 2)),
+#'                   climate = labelled(c(1L, 0L), c("cold" = 0, "warm" = 1)))
+#' 
+#' # Default: all data frames inherit labels from first df. Incorrect if
+#' # "reg 1" and "reg A" are from different countries, for example.
+#' dfA <- rbind_labelled(df1, df2)
+#' as_factor(dfA)
+#'
+#' # Concatenate value labels for "area". Regions are coded separately,
+#' # and original integer values are lost (by necessity of more levels now).
+#' # For "climate", codes "1 = hot" and "1 = warm", are coded as the same
+#' # outcome, inheriting "1 = hot" from df1 by default.
+#' dfB <- rbind_labelled(df1, df2, labels=list(area = "concatenate"))
+#' dfB
+#' as_factor(dfB)
+#'
+#' # We can specify to code as "1=warm/hot" rather than inheriting "hot".
+#' dfC <- rbind_labelled(df1, df2, labels=list(area = "concatenate", climate = c("cold"=0, "warm/hot"=1)))
+#' dfC$climate
+#' as_factor(dfC)
+#'
+#' # Or use `climate="concatenate"` to code "warm" and "hot" as different outcomes.
+#' dfD <- rbind_labelled(df1, df2, labels=list(area = "concatenate", climate="concatenate"))
+#' dfD
+#' as_factor(dfD)
+#'
+#' @export
+rbind_labelled <- function(..., labels=NULL, warn=TRUE){
+
+  dfs <- list(...)
+  if (is.list(dfs[[1]]) && !is.data.frame(dfs[[1]])) {
+    dfs <- dfs[[1]]
+  }
+
+  ## Ensure same column ordering for all dfs
+  dfs <- lapply(dfs, "[", names(dfs[[1]]))
+
+  islab <- sapply(dfs, sapply, is.labelled)
+  anylab <- names(which(apply(islab, 1, any)))
+
+  ## Convert "concatenated" variables to characters (will be converted back later).
+  catvar <- intersect(anylab, names(which(labels == "concatenate")))
+  dfs <- lapply(dfs, function(x){x[catvar] <- lapply(catvar, function(v) as.character(as_factor(x[[v]]))); x})
+  labels <- labels[!names(labels) %in% catvar]
+
+  islab <- sapply(dfs, sapply, is.labelled)
+  anylab <- names(which(apply(islab, 1, any)))
+  needslab <- setdiff(anylab, names(labels))
+
+  if(warn){
+    partlab <- intersect(names(which(apply(islab, 1, any) & !apply(islab, 1, all))), needslab)
+    if(length(partlab))
+      warning(paste("Some variables are only partially labelled:", paste(partlab, collapse=", ")))
+
+    lablist <- lapply(dfs, "[", intersect(anylab, needslab))
+    lablist <- lapply(lablist, lapply, attr, "labels")
+    lablist <- do.call(Map, c(f=list, lablist))
+
+    .check <- function(x) all(sapply(x, identical, x[[1]]))
+    allequal <- sapply(lablist, .check)
+    if(any(!allequal))
+      warning(paste0("Some variables have non-matching value labels: ",
+                     paste(names(allequal[!allequal]), collapse=", "),
+                     ".\nInheriting labels from first data frame."))
+  }
+
+  ## Grab inherited labels
+
+  whichlab <- apply(islab[needslab,,drop=FALSE], 1, function(x) min(which(x)))
+  if(length(whichlab)){
+    inherlab <- setNames(lapply(Map("[[", dfs[whichlab], names(whichlab)), attr, "labels"),
+                         names(whichlab))
+    labels <- c(labels, inherlab)
+  }
+
+  ## rbind data frames
+  df <- do.call(rbind, dfs)
+
+  ## Add labels
+  df[names(labels)] <- Map(haven::labelled, df[names(labels)], labels)
+
+  ## Convert concatenated variables back to labelled
+  df[catvar] <- lapply(df[catvar], factor)
+  df[catvar] <- lapply(df[catvar], function(x)
+    haven::labelled(as.integer(x), setNames(seq_along(levels(x)), levels(x))))
+
+  return(df)
+}

--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -1,15 +1,21 @@
-
 #' Parse .DCF file
 #'
 #' @title Parse .DCF dictionary file
 #' @param dcf .DCF file path to parse
+#' @param alllower logical indicating whether to convert variable labels to lower case. Defaults to `TRUE`.
 #' @return data.frame with metadata and labels as attributes
 #'
-#' @param zfile path to zip directory containing DHS flat file dataset.
-#' @param alllower logical indicating whether to convert variable labels to lower case. Defaults to `TRUE`.
-parse_dcf <- function(dcf){
-  
-  dcf <- readLines(dcf)
+#' @examples
+#' mrfl_zip <- tempfile()
+#' download.file("https://dhsprogram.com/customcf/legacy/data/sample_download_dataset.cfm?Filename=ZZMR61FL.ZIP&Tp=1&Ctry_Code=zz&survey_id=0&doctype=dhs", mrfl_zip)
+#'
+#' dcf <- read_zipdata(mrfl_zip, "\\.DCF", readLines)
+#' dct <- parse_dcf(dcf)
+#'
+#' @export
+parse_dcf <- function(dcf, all_lower=TRUE){
+
+  Sys.setlocale('LC_ALL','C')   ## !!! TODO
   
   item.start <- which(dcf == "[Item]")
   item.len <- diff(c(item.start, length(dcf)))
@@ -17,19 +23,7 @@ parse_dcf <- function(dcf){
   
   items <- lapply(item.idx, function(idx) paste(dcf[idx], collapse="\n"))
 
-  ## !WORK IN PROGRESS: parsing value labels
-  ## x <- vs[40]
-  ## .get_labels <- function(x){
-  ##   x <- strsplit(x, "\n")
-  ## id <- 
-  ## hasvs <- grepl("\\[ValueSet\\]", items)
-  ## vs <- gsub(".*?(\\[ValueSet\\].*)", "\\1", items[hasvs])
-  ## sub(".*?Name=([^/\n]*)\n.*", "\\1", items[[1]])
-  ## sub("\\[Item\\][^(\\[.*\\])]*Name=([^/\n]*)\n.*", "\\1", items[[1]])
-  ## sub("\[Item\][^(\n\[)]*Name=([^/\n]*)\n.*", "\\1", items[[1]])
-  
-  
-  dcf <- data.frame(name       = sub(".*?\nName=([^\n]*)\n.*", "\\1", items),
+  dcf <- data.frame(name       = tolower(sub(".*?\nName=([^\n]*)\n.*", "\\1", items)),
                     label      = sub(".*?\nLabel=([^\n]*)\n.*", "\\1", items),
                     start      = as.integer(sub(".*?\nStart=([^\n]*)\n.*", "\\1", items)),
                     len        = as.integer(sub(".*?\nLen=([^\n]*)\n.*", "\\1", items)),
@@ -42,16 +36,37 @@ parse_dcf <- function(dcf){
   
   has_occ <- grep(".*?\nOccurrences", items)
   dcf$occurences[has_occ] <- as.integer(sub(".*?\nOccurrences=([^\n]*)\n.*", "\\1", items[has_occ]))
+
+  ## add labels
+  hasvs <- grepl("\\[ValueSet\\]", items)
+  vs <- gsub(".*?(\\[ValueSet\\].*)", "\\1", items[hasvs])
+  vs <- strsplit(vs, "\n")
+  vs <- lapply(vs, grep, pattern="^Value=", value=TRUE)
+  values <- lapply(vs, gsub, pattern="^Value=([^;]*);?(.*)", replacement="\\1")
+
+  numericvar <- dcf$datatype[hasvs] == "Numeric"
+  values[numericvar] <- suppressWarnings(lapply(values[numericvar], as.integer))
+  values[!numericvar] <- lapply(values[!numericvar], gsub, pattern = "'\\s+'", replacement=NA)
+
+  labels <- lapply(vs, gsub, pattern="^Value=([^;]*);?(.*)", replacement="\\2")
+  if(all_lower)
+    labels <- lapply(labels, tolower)
+
+  values <- Map("names<-", values, labels)
+  values <- lapply(values, function(x) x[!is.na(x) & nchar(names(x)) > 0])
+
+  dcf$labels[hasvs] <- values
   
-  
-  .expand_occ <- function(name, label, start, len, datatype, occurences){
-    data.frame(name       = paste0(name, "_", formatC(seq_len(occurences), width=nchar(occurences), flag="0")),
-               label      = label,
-               len        = len,
-               start      = start - len + seq_len(occurences)*len,
-               occurences = 1,
-               datatype   = datatype,
-               stringsAsFactors = FALSE)
+  .expand_occ <- function(name, label, start, len, datatype, occurences, labels){
+    v <- data.frame(name       = paste0(name, "_", formatC(seq_len(occurences), width=nchar(occurences), flag="0")),
+                    label      = label,
+                    len        = len,
+                    start      = start - len + seq_len(occurences)*len,
+                    occurences = 1,
+                    datatype   = datatype,
+                    stringsAsFactors = FALSE)
+    v$labels <- list(labels)
+    return(v)
   }
   
   dct <- c(f=.expand_occ, dcf[dcf$occurences > 1,])
@@ -59,8 +74,48 @@ parse_dcf <- function(dcf){
   dct <- do.call(rbind, dct)
   dct <- rbind(dcf[dcf$occurences == 1,], dct)
   dct <- dct[order(dct$start),]
-  
-  ## tmp <- read.fwf(fwf, dct$len, col.names=dct$name)
 
   return(dct)
+}
+
+
+#' Read DHS flat file data set
+#'
+#' This function reads a DHS recode dataset from the zipped flat file dataset.
+#'
+#' @param zfile Path to `.zip` file containing flat file dataset, usually ending in filename `XXXXXXFL.zip`
+#' @param all_lower Logical indicating whether all value labels should be lower case. Default to `TRUE`.
+#' @return A data frame. Value labels for each variable are stored as the `labelled` class from `haven`.
+#'
+#' @seealso \code{\link{haven::labelled}}, \code{\link{read_dhs_dta}}.
+#'
+#' For more information on the DHS filetypes and contents of distributed dataset .ZIP files,
+#' see \url{https://dhsprogram.com/data/File-Types-and-Names.cfm#CP_JUMP_10334}.
+#'
+#' @examples
+#' mrfl_zip <- tempfile()
+#' download.file("https://dhsprogram.com/customcf/legacy/data/sample_download_dataset.cfm?Filename=ZZMR61FL.ZIP&Tp=1&Ctry_Code=zz&survey_id=0&doctype=dhs", mrfl_zip)
+#'
+#' mr <- read_dhs_flat(mrfl_zip)
+#' attr(mr$mv213, "label")
+#' class(mr$mv213)
+#' head(mr$mv213)
+#' table(mr$mv213)
+#' table(haven::as_factor(mr$mv213))
+#'
+#' @importFrom hhsurveydata read_zipdata
+#' @export
+read_dhs_flat <- function(zfile, all_lower=TRUE) {
+
+  dcf <- read_zipdata(zfile, "\\.DCF", readLines)
+  dct <- parse_dcf(dcf)
+  dct$col_types <- c("integer", "character")[match(dct$datatype, c("Numeric", "Alpha"))]
+  dat <- read_zipdata(zfile, "\\.DAT$", iotools::input.file,
+                      formatter = iotools::dstrfw, col_types = dct$col_types, widths = dct$len)
+  names(dat) <- dct$name
+  dat[dct$name] <- Map("attr<-", dat[dct$name], "label", dct$label)
+  haslbl <- sapply(dct$labels, length) > 0
+  dat[dct$name[haslbl]] <- Map(haven::labelled, dat[dct$name[haslbl]], dct$labels[haslbl])
+  
+  return(dat)
 }

--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -1,0 +1,66 @@
+
+#' Parse .DCF file
+#'
+#' @title Parse .DCF dictionary file
+#' @param dcf .DCF file path to parse
+#' @return data.frame with metadata and labels as attributes
+#'
+#' @param zfile path to zip directory containing DHS flat file dataset.
+#' @param alllower logical indicating whether to convert variable labels to lower case. Defaults to `TRUE`.
+parse_dcf <- function(dcf){
+  
+  dcf <- readLines(dcf)
+  
+  item.start <- which(dcf == "[Item]")
+  item.len <- diff(c(item.start, length(dcf)))
+  item.idx <- Map("+", item.start-1L, lapply(item.len, seq_len))
+  
+  items <- lapply(item.idx, function(idx) paste(dcf[idx], collapse="\n"))
+
+  ## !WORK IN PROGRESS: parsing value labels
+  ## x <- vs[40]
+  ## .get_labels <- function(x){
+  ##   x <- strsplit(x, "\n")
+  ## id <- 
+  ## hasvs <- grepl("\\[ValueSet\\]", items)
+  ## vs <- gsub(".*?(\\[ValueSet\\].*)", "\\1", items[hasvs])
+  ## sub(".*?Name=([^/\n]*)\n.*", "\\1", items[[1]])
+  ## sub("\\[Item\\][^(\\[.*\\])]*Name=([^/\n]*)\n.*", "\\1", items[[1]])
+  ## sub("\[Item\][^(\n\[)]*Name=([^/\n]*)\n.*", "\\1", items[[1]])
+  
+  
+  dcf <- data.frame(name       = sub(".*?\nName=([^\n]*)\n.*", "\\1", items),
+                    label      = sub(".*?\nLabel=([^\n]*)\n.*", "\\1", items),
+                    start      = as.integer(sub(".*?\nStart=([^\n]*)\n.*", "\\1", items)),
+                    len        = as.integer(sub(".*?\nLen=([^\n]*)\n.*", "\\1", items)),
+                    datatype   = "Numeric",
+                    occurences = 1,
+                    stringsAsFactors = FALSE)
+  
+  has_datatype <- grep(".*?\nDataType", items)
+  dcf$datatype[has_datatype] <- sub(".*?\nDataType=([^\n]*)\n.*", "\\1", items[has_datatype])
+  
+  has_occ <- grep(".*?\nOccurrences", items)
+  dcf$occurences[has_occ] <- as.integer(sub(".*?\nOccurrences=([^\n]*)\n.*", "\\1", items[has_occ]))
+  
+  
+  .expand_occ <- function(name, label, start, len, datatype, occurences){
+    data.frame(name       = paste0(name, "_", formatC(seq_len(occurences), width=nchar(occurences), flag="0")),
+               label      = label,
+               len        = len,
+               start      = start - len + seq_len(occurences)*len,
+               occurences = 1,
+               datatype   = datatype,
+               stringsAsFactors = FALSE)
+  }
+  
+  dct <- c(f=.expand_occ, dcf[dcf$occurences > 1,])
+  dct <- do.call(Map, dct)
+  dct <- do.call(rbind, dct)
+  dct <- rbind(dcf[dcf$occurences == 1,], dct)
+  dct <- dct[order(dct$start),]
+  
+  ## tmp <- read.fwf(fwf, dct$len, col.names=dct$name)
+
+  return(dct)
+}

--- a/vignettes/src/anemia.R
+++ b/vignettes/src/anemia.R
@@ -1,0 +1,234 @@
+#' ---
+#' title: "Anemia prevalence among women: an `rdhs` example"
+#' author: "OJ Watson, Jeff Eaton"
+#' date: "`r Sys.Date()`"
+#' output: pdf_document
+#' #  html_document: 
+#' #    smart: false
+#' vignette: >
+#'   %\VignetteIndexEntry{Vignette Title}
+#'   %\VignetteEngine{knitr::rmarkdown}
+#'   %\VignetteEncoding{UTF-8}
+#' ---
+
+#' Anemia is a common cause of fatigue, and women of childbearing age
+#' are at particularly high risk for anemia. The package `rdhs` can be used
+#' to compare estimates of the prevalence of any anemia among women from
+#' Demographic and Health Surveys (DHS) conducted in Armenia, Cambodia,
+#' and Lesotho.
+#'
+#' # Setup
+#' Load the `rdhs` package and establish a `dhs_client`. *Note: hopefully in future it will not be required to establish `dhs_client` to query the API.*
+## devtools::install_github("OJWatson/rdhs")
+library(rdhs)
+devtools::load_all()
+library(data.table)
+library(ggplot2)
+library(hhsurveydata)
+library(survey)
+library(haven)
+
+client <- rdhs::dhs_client(api_key = "ICLSPH-527168",
+                           credentials = "~/Documents/Data/DHS/rdhs/credentials")
+
+
+#' # Using calculated indicators from STATcompiler
+#'
+#' Anemia prevalence among women is reported as a core indicator through the DHS STATcompiler (https://www.statcompiler.com/).
+#' These indicators can be accessed directly from R via the DHS API with the function `dhs_data()`.
+#' 
+#' Query the API for a list of all StatCompiler indicators, and then search the indicators for those
+#' that have `"anemia"` in the indicator name. API calls return `data.table` objects. If package `data.table`
+#' is not loaded, they will be printed as `data.frame`s instead.
+#'
+#' *To do: wrapper function `dhs_indicators()` and search function*
+
+indicators <- client$dhs_api_request(api_endpoint = "indicators")
+tail(indicators[grepl("anemia", Label), .(IndicatorId, ShortName, Label)])
+
+#' The indicator ID `"AN_ANEM_W_ANY"` provides the percentage of women with any anemia.
+#' The function `dhs_data()` wiill query the indicator dataset for this indicator
+#' for our three countries of interest. First, use `dhs_countries()` to query the
+#' list of DHS countries to identify the DHS country code for each country.
+
+countries <- client$dhs_api_request(api_endpoint = "countries")
+dhscc <- countries[CountryName %in% c("Armenia", "Cambodia", "Lesotho"), DHS_CountryCode]
+dhscc
+#'
+#' Now query the indicators dataset for the women with any anemia indicator for these three countries.
+statcomp <- client$dhs_api_request(api_endpoint = "data",
+                                   query = list(indicatorIds = "AN_ANEM_W_ANY",
+                                                countryIds = dhscc))
+statcomp[,.(Indicator, CountryName, SurveyYear, Value, DenominatorWeighted)]
+
+##+ fig.height=2.5, fig.width=4, fig.align="center"
+ggplot(statcomp, aes(SurveyYear, Value, col=CountryName)) +
+  geom_point() + geom_line()
+
+
+#' # Analyse DHS microdata
+#'
+#' ## Identify surveys that include anemia testing
+#'
+#' The DHS API provides the facility to filter surveys according to particular characteristics.
+#' We first query the list of survey characteristics and identify the `SurveyCharacteristicID`
+#' that indicates the survey included anemia testing. The first command below queries the API
+#' for the full liest of survey characteristics, and the second uses `grepl()` to search
+#' `SurveyCharacteristicName`s that include the word 'anemia'.
+
+surveychar <- client$dhs_api_request(api_endpoint = "surveycharacteristics")
+surveychar[grepl("anemia", SurveyCharacteristicName, ignore.case=TRUE)]
+
+#' The `SurveyCharacteristicID = 41` indicates that the survey included anemia testing. Next we
+#' query the API to identify the surveys that have this characteristic and were conducted
+#' in our countries of interest.
+
+surveys <- client$dhs_api_request(api_endpoint = "surveys",
+                                  query = list(surveyCharacteristicIds = 41,
+                                               countryIds = dhscc))
+
+surveys[,.(SurveyId, CountryName, SurveyYear, NumberOfWomen, SurveyNum, FieldworkEnd)]
+
+#' Finally, query the API identify the individual recode (IR) survey datasets for each of these surveys
+
+datasets <- client$dhs_api_request(api_endpoint = "datasets",
+                                   query = list(SurveyIds = surveys$SurveyId,
+                                                fileType = "IR", 
+                                                fileFormat="stata"))
+datasets[, .(SurveyId, SurveyNum, FileDateLastModified, FileName)]
+
+
+#' ## Download datasets
+#'
+#' *In future, we will use the `dhs_client` to download and manage the IR datasets. For now, use
+#' datasets saved in a local archive.*
+#'
+#' Confirm that all identified datasets are in the local archive.
+
+all(tolower(datasets$FileName) %in% tolower(list.files("~/Documents/Data/DHS/all")))
+
+#' ## Identify survey variables
+#'
+#' Anemia is defined as having a hemoglobin (Hb) <12.0 g/dL for non-pregnant women
+#' or Hb <11.0 g/dL for currently pregnant women^[https://www.measureevaluation.org/prh/rh_indicators/womens-health/womens-nutrition/percent-of-women-of-reproductive-age-with-anemia].
+#' To calculate anemia prevalence from DHS microdata, we must identify the DHS recode
+#' survey variables for hemoglobin measurement and pregnancy status. This could be
+#' done by consulting the DHS recode manual or the .MAP files accompanying survey
+#' datasets. It is convenient though to do this in R by loading the first
+#' individual recode dataset and searching the metadata for the variable
+#' names corresponding to the hemoglobin measurement and pregnancy status.
+
+ir <- read_dhs_dta(file.path("~/Documents/Data/DHS/all", datasets$FileName[1]))
+head(grep("hemoglobin", sapply(ir, attr, "label"), value=TRUE))
+
+#' Variable `v042` records the household selection for hemoglobin testing.
+#' Variable `v455` reports the outcome of hemoglobin measurement and `v456`
+#' the result of altitude adjusted hemoglobin levels.
+table(as_factor(ir$v042))
+table(as_factor(ir$v455))
+summary(ir$v456)
+
+#' Variable `v454` reports the current pregnancy status used for determining the
+#' anemia threshold.
+grep("currently.*pregnant", sapply(ir, attr, "label"), value=TRUE)
+table(as_factor(ir$v454))
+
+#' We also keep a number of other variables related to the survey design and potentially
+#' interesting covariates: country code and phase (`v000`), cluster number (`v001`),
+#' sample weight (`v005`), age (`v012`), region (`v024`), urban/rural residence (`v025`),
+#' and education level (`v106`).
+
+vars <- c("SurveyId", "CountryName", "SurveyYear", "v000", "v001", "v005",
+          "v012", "v024", "v025", "v106", "v042", "v454", "v455", "v456")
+
+#' ## Extract survey data
+
+datlst <- list()
+
+for(i in 1:nrow(datasets)){
+
+  print(paste(i, datasets$SurveyId[i]))
+  ir <- read_dhs_dta(file.path("~/Documents/Data/DHS/all/", datasets$FileName[i]))
+  
+  ir$SurveyId <- datasets$SurveyId[i]
+  ir$CountryName <- datasets$CountryName[i]
+  ir$SurveyYear <- datasets$SurveyYear[i]
+
+  datlst[[datasets$SurveyId[i]]] <- ir[vars]
+}
+
+#' We use `rbind_labelled()` to combine datasets with labelled columns. The argument
+#' `labels` describes to combine variable levels for all datasets for `v024` (region)
+#' while providing a consistent set of value labels to be used for `v454` (currently
+#' pregnant) for all datasets.
+#' 
+dat <- rbind_labelled(datlst,
+                      labels = list(v024 = "concatenate",
+                                    v454 = c("no/don't know" = 0L,
+                                             "yes" = 1L, "missing" = 9L)))
+                                                     
+sapply(dat, is.labelled)
+dat$v456 <- zap_labels(dat$v456)
+dat <- as_factor(dat)
+
+#' ## Data tabulations
+#'
+#' It is a good idea to check basic tabulations of the data, especially by
+#' survey to identify and nuances Exploratory analysis of variables
+with(dat, table(SurveyId, v025, useNA="ifany"))
+with(dat, table(SurveyId, v024, useNA="ifany"))
+with(dat, table(SurveyId, v106, useNA="ifany"))
+with(dat, table(SurveyId, v454, useNA="ifany"))
+with(dat, table(SurveyId, v455, useNA="ifany"))
+
+with(dat, table(v042, v454, useNA="ifany"))
+
+#' ## Calculate anemia prevalence
+
+#' Create indicator variable for 'any anemia'. The threshold depends on pregnancy status.
+dat$v456[dat$v456 == 999] <- NA
+with(dat, table(v455, is.na(v456)))
+dat$anemia <- as.integer(dat$v456  < ifelse(dat$v454 == "yes", 110, 120))
+dat$anemia_denom <- as.integer(!is.na(dat$anemia))
+
+#' Specify survey design using the `survey` package.
+dat$w <- dat$v005/1e6
+des <- svydesign(~v001+SurveyId, data=dat, weights=~w)
+
+anemia_prev <- svyby(~anemia, ~SurveyId, des, svyciprop, na.rm=TRUE, vartype="ci")
+anemia_denom <- svyby(~anemia_denom, ~SurveyId, des, svytotal, na.rm=TRUE)
+
+anemia_prev <- merge(anemia_prev, anemia_denom[c("SurveyId", "anemia_denom")])
+res <- statcomp[,.(SurveyId, CountryName, SurveyYear, Value, DenominatorUnweighted, DenominatorWeighted)][anemia_prev, on="SurveyId"]
+
+res$anemia <- 100*res$anemia
+res$ci_l <- 100*res$ci_l
+res$ci_u <- 100*res$ci_u
+res$anemia_denom0 <- round(res$anemia_denom)
+
+#' The table below compares the prevalence of any anemia calcuated from survey microdata
+#' with the estimates from DHS StatCompiler and the weighted denominators for each
+#' calculation. The estimates are identical for most cases. There are some small
+#' differences to be ironed out.
+knitr::kable(res[,.(CountryName, SurveyYear, Value, anemia, ci_l, ci_u, DenominatorWeighted, anemia_denom0)], digits=1)
+
+##+ fig.height=2.5, fig.width=4, fig.align="center"
+ggplot(anemia_prev, aes(x=SurveyYear, y=anemia, ymin=ci_l, ymax=ci_u,
+                        col=CountryName, fill=CountryName)) +
+  geom_ribbon(alpha=0.4, linetype="blank") + geom_point() + geom_line()
+
+  
+
+#'
+#' # Regression analysis: relationship between education and anemia
+#'
+#' A key use of the survey microdata are to conduct secondary analysis of pooled data
+#' from several surveys, such as regression analysis. Here we investigate the
+#' relationship between anemia prevalence and education level (`v106`) for women using
+#' logistic regression, adjusting for urban/rural (`v025`) and fixed effects for each
+#' survey.
+
+des <- update(des, v106 = relevel(v106, "primary"))
+summary(svyglm(anemia ~ SurveyId + v025 + v106, des, family="binomial"))
+
+#' The results suggest a strong gradient in lower anemia prevalence associated with higher education among women.


### PR DESCRIPTION
There are two commits. The first develops a workflow for reading and pooling datasets from DHS Stata datasets:
1. Read datasets with underlying value codes.
2. Parse data dictionary from .MAP file and manually apply variable and value labels.
3. Combine data using rbind_labelled() with options for handling labelled data.

The second commit adds a vignette for calculating anemia prevalence to demonstrate envisioned workflow.