### PR TITLE
fix my gold bar (data.table nugget)

### DIFF
--- a/R/API.R
+++ b/R/API.R
@@ -59,7 +59,7 @@ handle_api_request <- function(endpoint, query, all_results, client,
 
     # check out agianst cache, if fine return that and if not make request
     if (!is.null(out) && !force) {
-      return(out)
+      resp <- out
     } else {
 
       # create generic request


### PR DESCRIPTION
`data.table` nugget didn't work for cached API calls because of early return().