### PR TITLE
update parse_dcf(): regex allow endline in DataType parser

### DIFF
--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -51,9 +51,8 @@ parse_dcf <- function(dcf, all_lower=TRUE) {
     occurences = 1,
     stringsAsFactors = FALSE
   )
-
   has_datatype <- grep(".*?\nDataType", items)
-  dcf$datatype[has_datatype] <- sub(".*?\nDataType=([^\n]*)\n.*", "\\1",
+  dcf$datatype[has_datatype] <- sub(".*?\nDataType=([^\n]*)(\n.*|$)", "\\1",
                                     items[has_datatype])
 
   has_occ <- grep(".*?\nOccurrences", items)


### PR DESCRIPTION
Patches parser error for Nepal 2006 IR dataset.  Issue was that DataType field was last line of DCF file, and so did not end in a `\n` which was searched by regex parser.