### PR TITLE
when printing config, check first if there is a password before obscu…

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -270,10 +270,7 @@ write_rdhs_config_file <- function(dat, path) {
     "Writing your configuration to:\n   -> ", path, "\n"
   )
 
-  # and add this to the build and gitignore if there
-  if (file.exists("DESCRIPTION")) {
-    add_line(".Rbuildignore", gsub("\\.", "\\\\.", path))
-  }
+  # and add this to gitignore if there
   add_line(".gitignore", path)
 
   writeLines(str, path)
@@ -404,7 +401,11 @@ print_rdhs_config <- function(config, give.attr = FALSE) {
   ga <- give.attr
   config$data_frame <- config$data_frame_nice
   config$data_frame_nice <- NULL
+
+  # if there is a password in the config then let's not print it
+  if (!is.null(config$password)) {
   config$password <- paste0(rep("*", nchar(config$password)),collapse="")
+  }
   message(paste0(capture.output(str(config, give.attr = ga)), collapse = "\n"))
   message("\n")
 

--- a/tests/testthat/helper_authentication.R
+++ b/tests/testthat/helper_authentication.R
@@ -44,7 +44,8 @@ new_rand_client <- function() {
 
   # to enable the test suite to work without the encoded rdhs.json we'll create
   if (!file.exists("rdhs.json")) {
-    set_rdhs_config(config_path = "rdhs.json", global = FALSE, password_prompt = FALSE)
+    options("rappdir_permission" = TRUE)
+    set_rdhs_config(config_path = "rdhs.json", global = FALSE, prompt = FALSE)
   }
     cli <- rdhs::client_dhs(
       api_key = "ICLSPH-527168",

--- a/tests/testthat/test_api_endpoints.R
+++ b/tests/testthat/test_api_endpoints.R
@@ -8,6 +8,7 @@ test_that("format catches and all_results tests", {
   testthat::skip_on_cran()
 
   # Create new directory
+  old_config <- if(file.exists("rdhs.json")) "rdhs.json" else NULL
   cli <- new_rand_client()
 
   dat <- api_timeout_safe_test(
@@ -64,12 +65,18 @@ test_that("format catches and all_results tests", {
     ), cli
   )
   expect_true(inherits(dat, "data.table"))
-
   Sys.setenv("rdhs_DATA_TABLE" = FALSE)
+
+  # if we created a config for these tests then remove it
+  if(is.null(old_config)){
+    file.remove("rdhs.json")
+  }
+
 })
 
 test_that("geojson works", {
 
+  testthat::skip("geojson test too heavy an API test")
   testthat::skip_on_cran()
   testthat::skip_on_travis()
   skip_if_slow_API()
@@ -333,4 +340,19 @@ test_that("dhs_uiUpdates works", {
     dhs_ui_updates(lastUpdate = "20150901", all_results = FALSE), cli
   )
   expect_true(any(dat$Interface %in% "Surveys"))
+
+})
+
+test_that("post api tidy", {
+
+  if (file.exists("rdhs.json")) {
+  conf <- read_rdhs_config_file("rdhs.json")
+  } else {
+    expect_true(TRUE)
+  }
+
+  if (is.null(conf$email)){
+    expect_true(file.remove("rdhs.json"))
+  }
+
 })

--- a/tests/testthat/test_miscellaneous.R
+++ b/tests/testthat/test_miscellaneous.R
@@ -74,10 +74,13 @@ test_that("different locales", {
 test_that("password obscure", {
 
   # what is the config
+  if (file.exists("rdhs.json")) {
   config <- read_rdhs_config_file("rdhs.json")
 
   # the message should have * in
   mes <- paste0(rep("*", nchar(config$password)), collapse="")
   expect_message(print_rdhs_config(config), regexp = mes, fixed = TRUE)
-
+  } else {
+  skip("No authentication available for password test")
+}
 })


### PR DESCRIPTION
…ring it. It is possible for someone to create a config without a password and so this should be checked.

Associated tests and tidies

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
