### PR TITLE
Move info regarding account setup to getting started, embolden key in…

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -23,10 +23,6 @@ The Demographic and Health Surveys (DHS) Program has collected population survey
 
 ---
 
- > To be able to download survey datasets from the DHS website, you will need to set up an account with the DHS website, which will enable you to request access to the datasets. Instructions on how to do this can be found [here](https://dhsprogram.com/data/Access-Instructions.cfm). The email, password, and project name that were used to create the account will then need to be provided to `rdhs` when attempting to download datasets. 
-
----
-
 `rdhs` is a package for management and analysis of [Demographic and Health Survey (DHS)](https://www.dhsprogram.com) data. This includes functionality to:
 
 1. Access standard indicator data (i.e. [DHS STATcompiler](https://www.statcompiler.com/)) in R via the [DHS API](https://api.dhsprogram.com/).
@@ -46,6 +42,10 @@ library(rdhs)
 ```
 
 ## Getting started
+
+To be able to **download survey datasets from the DHS website**, you will need to **set up an account with the DHS website**, which will enable you to request access to the datasets. Instructions on how to do this can be found [here](https://dhsprogram.com/data/Access-Instructions.cfm). The email, password, and project name that were used to create the account will then need to be provided to `rdhs` when attempting to download datasets. 
+
+---
 
 * Request dataset access from the DHS website [here](https://dhsprogram.com/data/Access-Instructions.cfm).
 


### PR DESCRIPTION
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Minor edits to the `README.Rmd `to place info regarding account setup prominently in the appropriate subsection (Getting Started, right after install instructions). I also removed the blockquote which visually seemed to lessen the impact of the information. Instead, I highlighted the key information in **bold**. I tried to render it to `README.md` but couldn't because of lack of credentials so that still needs doing. Sorry to push a half job! 😬

Also, apologies for making the PR to master, it just seemed that it's ahead of `development` at the minute so I'm assuming holds the most up to date version of the code? 
